### PR TITLE
Allow mutations of events before send to ClickHouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Please note that the name of the plugin when used is `clickhouse`, it only suppo
         http_hosts => ["http://your.clickhouse1/", "http://your.clickhouse2/", "http://your.clickhouse3/"]
         table => "table_name"
         mutations => {
-          from => "to",
-          from => [ "to", /(.)(.)/, 2, 1 ]
+          "to1" => "from1",
+          "to2" => [ "from2", /(.)(.)/, '\1\2' ]
         }
       }
     }


### PR DESCRIPTION
Allow mutations of events before send to ClickHouse:

```
        mutations => {
          from => "to",
          from => [ "to", /(.)(.)/, 2, 1 ]
        }
```