### PR TITLE
fix mutate doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please note that the name of the plugin when used is `clickhouse`, it only suppo
         http_hosts => ["http://your.clickhouse1/", "http://your.clickhouse2/", "http://your.clickhouse3/"]
         table => "table_name"
         mutations => {
-          "to1" => "from1",
+          "to1" => "from1"
           "to2" => [ "from2", "(.)(.)", '\1\2' ]
         }
       }


### PR DESCRIPTION
Mutations don't work if comma present
```
Failed to execute action {:action=>LogStash::PipelineAction::Create/pipeline_id:main, :exception=>"LogStash::ConfigurationError", :message=>"Expected one of #, {, } at line 59, column 36 (byte 1584) after output {\n      \n        clickhouse {\n            http_hosts => [\"http://test3-click:8123\"]\n            table => \"amaterasu.mylog\"\n            request_tolerance => 1\n            flush_size => 1000\n            pool_max => 1000\n            mutations => {\n                     \"pid\" => \"pid\"",
```